### PR TITLE
Removed keywords, component default, add helper

### DIFF
--- a/components/Seo.php
+++ b/components/Seo.php
@@ -30,8 +30,7 @@ class Seo extends ComponentBase
 		$seo = SeoModel::where('page', $this->page->baseFileName)->first();
 		if ($seo) {
 			$this->page->title = $seo->title . ($this->property('append') ? (' ' . $this->property('append')) : '');
-			$this->page->description = $seo->description;
-            $this->page->keywords = $seo->keywords;
+			$this->page->description = $seo->description;            
 			$this->page->seo_image = $seo->image;
 		}
 	}

--- a/components/Seo.php
+++ b/components/Seo.php
@@ -6,13 +6,16 @@ use \RainLab\Translate\Classes\Translator;
 
 class Seo extends ComponentBase
 {
-	public function componentDetails()
-	{
-		return [
-			'name'			=> 'fw.seo::lang.component_seo.name',
-			'description'	=> 'fw.seo::lang.component_seo.description'
-		];
-	}
+    // Boolean which reflects whether or not the current page has an SEO page
+    protected $hasSeo = false;
+
+    public function componentDetails()
+    {
+        return [
+            'name'			=> 'fw.seo::lang.component_seo.name',
+            'description'	=> 'fw.seo::lang.component_seo.description'
+        ];
+    }
 
     public function defineProperties()
     {
@@ -25,14 +28,23 @@ class Seo extends ComponentBase
         ];
     }
 
-	public function onRun()
-	{
-		$seo = SeoModel::where('page', $this->page->baseFileName)->first();
-		if ($seo) {
-			$this->page->title = $seo->title . ($this->property('append') ? (' ' . $this->property('append')) : '');
-			$this->page->description = $seo->description;            
-			$this->page->seo_image = $seo->image;
-		}
-	}
+    public function onRun()
+    {
+        $seo = SeoModel::where('page', $this->page->baseFileName)->first();
+        
+        if ($seo) {
+            $this->hasSeo = true; 
+            $this->page->title = $seo->title . ($this->property('append') ? (' ' . $this->property('append')) : '');
+            $this->page->description = $seo->description;
+            $this->page->seo_image = $seo->image;
+        }
+    }
 
+    /**
+     * Returns true if the current page has an SEO page defined, false otherwise
+     */
+    public function hasSeoPage()
+    {
+        return $this->hasSeo;
+    }
 }

--- a/components/seo/default.htm
+++ b/components/seo/default.htm
@@ -1,0 +1,12 @@
+
+    <title>{{ this.page.title }}</title>
+    {% if seo.hasSeoPage %}
+    <meta name="description" content="{{ this.page.description }}" />
+    <meta name="title" content="{{ this.page.title }}" />
+
+    <meta property="og:title" content="{{ this.page.title }}" />
+    <meta property="og:description" content="{{ this.page.description }}" />
+      {% if this.page.seo_image %}
+    <meta property="og:image" content="{{ this.page.seo_image.getPath() }}" />
+      {% endif %}
+    {% endif %}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -20,7 +20,6 @@ return [
         'page' => 'Page',
         'title' => 'Title',
         'description' => 'Description',
-        'keywords' => 'Keywords (separated with a ,)',
         'image' => 'Social Networks Image'
     ],
 ];

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -21,7 +21,6 @@ return [
         'page' => 'Página',
         'title' => 'Título',
         'description' => 'Descripción',
-        'keywords' => 'Palabras clave (separadas con ,)',
         'image' => 'Imagen para redes sociales'
     ],
 ];

--- a/models/Seo.php
+++ b/models/Seo.php
@@ -10,7 +10,7 @@ class Seo extends Model
 {
     use \October\Rain\Database\Traits\Validation;
 
-    public $implement = ['RainLab.Translate.Behaviors.TranslatableModel'];
+    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
 
     /**
      * @var string The database table used by the model.
@@ -23,14 +23,12 @@ class Seo extends Model
     public $rules = [
         'page' => 'required|unique:fw_seo_pages',
         'title' => 'required|max:70',
-        'description' => 'required|max:155',
-        'keywords' => 'required|max:255',
+        'description' => 'required|max:155'
     ];
 
     public $translatable = [
     	'title',
-    	'description',
-        'keywords'
+    	'description'
     ];
 
     public $attachOne = [

--- a/models/seo/columns.yaml
+++ b/models/seo/columns.yaml
@@ -14,5 +14,3 @@ columns:
         label: fw.seo::lang.seo.title
     description:
         label: fw.seo::lang.seo.description
-    keywords:
-        label: fw.seo::lang.seo.keywords

--- a/models/seo/fields.yaml
+++ b/models/seo/fields.yaml
@@ -17,11 +17,6 @@ fields:
         span: left
         attributes:
             maxlength: 155
-    keywords:
-        label: fw.seo::lang.seo.keywords
-        span: left
-        attributes:
-            maxlength: 255
     image:
         label: fw.seo::lang.seo.image
         type: fileupload

--- a/updates/create_pages_table.php
+++ b/updates/create_pages_table.php
@@ -14,8 +14,7 @@ class CreatePagesTable extends Migration
             $table->increments('id');
             $table->string('page');
             $table->string('title');
-            $table->string('description');
-            $table->string('keywords')->nullable();
+            $table->string('description');            
         });
     }
 


### PR DESCRIPTION
Hi there!

I've made a few changes and additions to your plugin, everything is only a suggestion of course!

1. I've removed the keywords, they are not used anymore since roughly 2009 and have zero influence on ranking or any other SEO factor. 

2. I've added a component output file (default.htm), which allows us to simply add the component to the default layout like so: 
```
{% component 'seo' %}
```
This will be replaced with the following:
```
<title>{{ this.page.title }}</title>
{% if seo.hasSeoPage %}
    <meta name="description" content="{{ this.page.description }}" />
    <meta name="title" content="{{ this.page.title }}" />

    <meta property="og:title" content="{{ this.page.title }}" />
    <meta property="og:description" content="{{ this.page.description }}" />
    {% if this.page.seo_image %}
        <meta property="og:image" content="{{ this.page.seo_image.getPath() }}" />
    {% endif %}
{% endif %}
```

3. I've changed your implementation of the Rainlab.Translate plugin to a soft implementation, meaning that your plugin will also work without the translation plugin present, which makes a lot of sense I think!

4. I've added a little helper method to conditionally render the meta tags hasSeoPage()

I'm sure we can also add staticPages plugin support over time ;-) 
